### PR TITLE
Added View Options to Match Team View

### DIFF
--- a/VRC RoboScout/EventTeamMatches.swift
+++ b/VRC RoboScout/EventTeamMatches.swift
@@ -17,12 +17,10 @@ enum AlertText: String {
 }
 
 struct EventTeamMatches: View {
-    
     @EnvironmentObject var settings: UserSettings
     @EnvironmentObject var dataController: RoboScoutDataController
     
     @Binding var teams_map: [String: String]
-    
     @State var event: Event
     @State var team: Team
     @State var division: Division?
@@ -206,7 +204,7 @@ struct EventTeamMatches: View {
             }
         }
     }
-        
+
     var body: some View {
         VStack {
             if showLoading {

--- a/VRC RoboScout/EventTeamView.swift
+++ b/VRC RoboScout/EventTeamView.swift
@@ -31,17 +31,17 @@ struct EventTeamView: View {
     var body: some View {
         VStack {
             Picker("Team Information", selection: $selectedView) {
-                Text("Matches").tag(UserSettings.getTeamInfoDefaultPage() == "events" ? 0 : 1)
-                Text("Statistics").tag(UserSettings.getTeamInfoDefaultPage() == "statistics" ? 0 : 1)
+                Text("Matches").tag(UserSettings.getMatchTeamDefaultPage() == "matches" ? 0 : 1)
+                Text("Statistics").tag(UserSettings.getMatchTeamDefaultPage() == "statistics" ? 0 : 1)
             }.pickerStyle(.segmented).padding()
             Spacer()
             if selectedView == (UserSettings.getMatchTeamDefaultPage() == "matches" ? 0 : 1) {
-                TeamLookup(team_number: teamNumber, editable: false, fetch: true)
+                EventTeamMatches(teams_map: $teams_map, event: event, team: Team(number: teamNumber, fetch: false), division: division)
                     .environmentObject(settings)
                     .environmentObject(dataController)
             }
             else if selectedView == (UserSettings.getMatchTeamDefaultPage() == "statistics" ? 0 : 1) {
-                EventTeamMatches(teams_map: $teams_map, event: event, team: Team(number: teamNumber, fetch: false), division: division)
+                TeamLookup(team_number: teamNumber, editable: false, fetch: true)
                     .environmentObject(settings)
                     .environmentObject(dataController)
             }

--- a/VRC RoboScout/EventTeamView.swift
+++ b/VRC RoboScout/EventTeamView.swift
@@ -1,0 +1,62 @@
+//
+//  EventTeamView.swift
+//  VRC RoboScout
+//
+//  Created by Ali Macky on 3/17/24.
+//
+
+import SwiftUI
+import CoreData
+
+struct EventTeamView: View {
+    
+    @EnvironmentObject var settings: UserSettings
+    @EnvironmentObject var dataController: RoboScoutDataController
+    
+    @Binding var teams_map: [String: String]
+    
+    @State var event: Event
+    @State var division: Division?
+    @State var teamNumber: String
+    @State var selectedView = 0
+    
+    init(teams_map: Binding<[String: String]>, event: Event, teamNumber: String, division: Division? = nil) {
+        self._teams_map = teams_map
+        self._event = State(initialValue: event)
+        self._teamNumber = State(initialValue: teamNumber)
+        self._division = State(initialValue: division)
+    }
+    
+    
+    var body: some View {
+        VStack {
+            Picker("Team Information", selection: $selectedView) {
+                Text("Matches").tag(UserSettings.getTeamInfoDefaultPage() == "events" ? 0 : 1)
+                Text("Statistics").tag(UserSettings.getTeamInfoDefaultPage() == "statistics" ? 0 : 1)
+            }.pickerStyle(.segmented).padding()
+            Spacer()
+            if selectedView == (UserSettings.getMatchTeamDefaultPage() == "matches" ? 0 : 1) {
+                TeamLookup(team_number: teamNumber, editable: false, fetch: true)
+                    .environmentObject(settings)
+                    .environmentObject(dataController)
+            }
+            else if selectedView == (UserSettings.getMatchTeamDefaultPage() == "statistics" ? 0 : 1) {
+                EventTeamMatches(teams_map: $teams_map, event: event, team: Team(number: teamNumber, fetch: false), division: division)
+                    .environmentObject(settings)
+                    .environmentObject(dataController)
+            }
+        }.background(.clear)
+            .toolbar {
+                ToolbarItem(placement: .principal) {
+                    Text("Team Info")
+                        .fontWeight(.medium)
+                        .font(.system(size: 19))
+                        .foregroundColor(settings.navTextColor())
+                }
+            }
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarBackground(settings.tabColor(), for: .navigationBar)
+            .toolbarBackground(.visible, for: .navigationBar)
+            .tint(settings.accentColor())
+    }
+}

--- a/VRC RoboScout/EventTeams.swift
+++ b/VRC RoboScout/EventTeams.swift
@@ -92,7 +92,7 @@ struct EventTeams: View {
                 NavigationView {
                     List {
                         ForEach(searchResults, id: \.self) { teamNum in
-                            NavigationLink(destination: EventTeamMatches(teams_map: $teams_map, event: event, team: Team(number: teamNum, fetch: false), division: division).environmentObject(settings).environmentObject(dataController)) {
+                            NavigationLink(destination: EventTeamView(teams_map: $teams_map, event: event, teamNumber: teamNum, division: division).environmentObject(settings).environmentObject(dataController)) {
                                 HStack {
                                     Text((event_teams_map[teamNum] ?? Team()).number).font(.system(size: 20)).minimumScaleFactor(0.01).frame(width: 80, height: 30, alignment: .leading).bold()
                                     VStack {

--- a/VRC RoboScout/Settings.swift
+++ b/VRC RoboScout/Settings.swift
@@ -23,6 +23,7 @@ struct Settings: View {
     @State var selected_season_id = UserSettings.getSelectedSeasonID()
     @State var apiKey = UserSettings.getRobotEventsAPIKey() ?? ""
     @State var team_info_default_page = UserSettings.getTeamInfoDefaultPage() == "statistics"
+    @State var match_team_default_page = UserSettings.getMatchTeamDefaultPage() == "statistics"
     @State var showLoading = false
     @State var showApply = false
     @State var clearedTeams = false
@@ -163,6 +164,10 @@ struct Settings: View {
                 Section("Customization") {
                     Toggle("Show statistics by default on Team Info page", isOn: $team_info_default_page).onChange(of: team_info_default_page) { _ in
                         settings.setTeamInfoDefaultPage(page: team_info_default_page ? "statistics" : "events")
+                        settings.updateUserDefaults()
+                    }
+                    Toggle("Show statistics by default on Match Team page", isOn: $match_team_default_page).onChange(of: match_team_default_page) { _ in
+                        settings.setMatchTeamDefaultPage(page: match_team_default_page ? "statistics" : "matches")
                         settings.updateUserDefaults()
                     }
                 }

--- a/VRC RoboScout/VRCRoboScoutApp.swift
+++ b/VRC RoboScout/VRCRoboScoutApp.swift
@@ -187,6 +187,7 @@ class UserSettings: ObservableObject {
     private var grade_level: String
     private var performance_ratings_calculation_option: String
     private var team_info_default_page: String
+    private var match_team_default_page: String
     private var selected_season_id: Int
     
     static var keyIndex = Int.random(in: 0..<10)
@@ -198,6 +199,7 @@ class UserSettings: ObservableObject {
         self.grade_level = defaults.object(forKey: "grade_level") as? String ?? "High School"
         self.performance_ratings_calculation_option = defaults.object(forKey: "performance_ratings_calculation_option") as? String ?? "real"
         self.team_info_default_page = defaults.object(forKey: "team_info_default_page") as? String ?? "events"
+        self.match_team_default_page = defaults.object(forKey: "match_team_default_page") as? String ?? "matches"
         self.selected_season_id = defaults.object(forKey: "selected_season_id") as? Int ?? 181
     }
     
@@ -208,6 +210,7 @@ class UserSettings: ObservableObject {
         self.grade_level = defaults.object(forKey: "grade_level") as? String ?? "High School"
         self.performance_ratings_calculation_option = defaults.object(forKey: "performance_ratings_calculation_option") as? String ?? "real"
         self.team_info_default_page = defaults.object(forKey: "team_info_default_page") as? String ?? "events"
+        self.match_team_default_page = defaults.object(forKey: "match_team_default_page") as? String ?? "matches"
         self.selected_season_id = defaults.object(forKey: "selected_season_id") as? Int ?? API.selected_season_id()
     }
     
@@ -218,6 +221,7 @@ class UserSettings: ObservableObject {
         defaults.set(self.grade_level, forKey: "grade_level")
         defaults.set(self.performance_ratings_calculation_option, forKey: "performance_ratings_calculation_option")
         defaults.set(self.team_info_default_page, forKey: "team_info_default_page")
+        defaults.set(self.match_team_default_page, forKey: "match_team_default_page")
         defaults.set(self.selected_season_id, forKey: "selected_season_id")
     }
     
@@ -243,6 +247,10 @@ class UserSettings: ObservableObject {
     
     func setTeamInfoDefaultPage(page: String) {
         self.team_info_default_page = page
+    }
+    
+    func setMatchTeamDefaultPage(page: String) {
+        self.match_team_default_page = page
     }
     
     func setSelectedSeasonID(id: Int) {
@@ -311,6 +319,10 @@ class UserSettings: ObservableObject {
     
     static func getTeamInfoDefaultPage() -> String {
         return defaults.object(forKey: "team_info_default_page") as? String ?? "events"
+    }
+    
+    static func getMatchTeamDefaultPage() -> String {
+        return defaults.object(forKey: "match_team_default_page") as? String ?? "matches"
     }
 
     static func getSelectedSeasonID() -> Int {


### PR DESCRIPTION
### Options
- Matches
- Statistics

### Features 
- View Switcher
- Toggle for statistics page default in settings

<img width="431" alt="MatchTeamInfoPage" src="https://github.com/SunkenSplash/VRC-RoboScout/assets/101155766/1f2f275a-66e0-4cc7-89e5-afd2baed9589">
 
<img width="428" alt="SettingsView" src="https://github.com/SunkenSplash/VRC-RoboScout/assets/101155766/fbfc128c-043c-4ede-8e52-fe80979c10f2">
